### PR TITLE
Add support for encodeNilAsNull

### DIFF
--- a/Sources/IkigaJSON/Codable/JSONEncoder.swift
+++ b/Sources/IkigaJSON/Codable/JSONEncoder.swift
@@ -23,8 +23,6 @@ public struct JSONEncoderSettings {
     /// This is `false` by default
     public var encodeNilAsNull = false
     
-    // TODO: Support
-    
     /// Defines the method used when encode keys
     public var keyEncodingStrategy = JSONEncoder.KeyEncodingStrategy.useDefaultKeys
     
@@ -375,7 +373,202 @@ fileprivate struct KeyedJSONEncodingContainer<Key: CodingKey>: KeyedEncodingCont
     mutating func encode(_ value: UInt64, forKey key: Key) throws {
         encoder.writeValue(value, forKey: key.stringValue)
     }
-    
+
+    mutating func encodeIfPresent(_ value: Int?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: Int8?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: Int16?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: Int32?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: Int64?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: UInt?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: UInt8?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: Float?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: Double?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: Bool?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: String?, forKey key: Key) throws {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
+    mutating func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
+        if let value = value {
+            try self.encode(value, forKey: key)
+            return
+        }
+
+        guard encoder.settings.encodeNilAsNull else {
+            return
+        }
+
+        try self.encodeNil(forKey: key)
+    }
+
     mutating func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
         self.encoder.writeKey(key.stringValue)
         let encoder = _JSONEncoder(codingPath: codingPath + [key], userInfo: self.encoder.userInfo, settings: self.encoder.settings)


### PR DESCRIPTION
Hey.

Here lies a pretty naive implementation for the `encodeNilAsNull` JSON encoder setting. It seems that the default implementation of the `encodeIfPresent` functions doesn't do anything if the value was nil – but overriding each variation works without having to touch the Encodable classes.