### PR TITLE
Add @available attribute for iOS version also

### DIFF
--- a/Sources/IkigaJSON/Codable/JSONDecoder.swift
+++ b/Sources/IkigaJSON/Codable/JSONDecoder.swift
@@ -1,7 +1,7 @@
 import Foundation
 import NIO
 
-@available(OSX 10.12, *)
+@available(OSX 10.12, iOS 11, *)
 let isoFormatter = ISO8601DateFormatter()
 let isoDateFormatter: DateFormatter = {
     let formatter = DateFormatter()

--- a/Sources/IkigaJSON/Codable/JSONDecoder.swift
+++ b/Sources/IkigaJSON/Codable/JSONDecoder.swift
@@ -1,7 +1,7 @@
 import Foundation
 import NIO
 
-@available(OSX 10.12, iOS 11, *)
+@available(OSX 10.12, iOS 10, *)
 let isoFormatter = ISO8601DateFormatter()
 let isoDateFormatter: DateFormatter = {
     let formatter = DateFormatter()


### PR DESCRIPTION
I added IkigaJSON as a package in my Xcode 11-GM iOS project. The build failed due to ISO8601DateFormatter not being available before iOS 10, but I got it resolved in my fork my simply adding the check in available attribute.